### PR TITLE
修复Celery配置与异步任务查询的错误，并补充测试

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -219,7 +219,7 @@ curl http://localhost:8000/api/v1/health
 ├── app/                        # 后端应用
 │   ├── __init__.py
 │   ├── main_production.py      # 生产版主程序 ⭐
-│   ├── main_debug.py          # 调试版主程序
+│   ├── main.py                # 本地开发主程序
 │   ├── api/                   # API路由
 │   │   └── v1/
 │   │       └── endpoints.py   # API端点定义

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -6,7 +6,7 @@ import hashlib
 from app.models.schemas import TextRequest, ProcessResult, AsyncTaskResponse
 from app.models.database import get_db, ProcessingHistory
 from app.services.ai_processor import ai_processor
-from app.services.celery_app import long_text_processing
+from app.services.celery_app import celery_app, long_text_processing
 
 router = APIRouter()
 
@@ -77,7 +77,7 @@ async def async_process_text(
 async def get_task_status(task_id: str):
     """查询异步任务状态"""
     try:
-        task = long_text_processing.AsyncResult(task_id)
+        task = celery_app.AsyncResult(task_id)
         
         if task.state == 'PENDING':
             return {"task_id": task_id, "status": "pending", "message": "任务等待中"}

--- a/app/services/celery_app.py
+++ b/app/services/celery_app.py
@@ -6,10 +6,10 @@ celery_app = Celery(
     "ai_processor",
     broker=settings.redis_url,
     backend=settings.redis_url,
-    include=['app.services.tasks']
+    include=['app.services.celery_app']
 )
 
-# Celery配置设置
+# Celery配置
 celery_app.conf.update(
     task_serializer='json',
     accept_content=['json'],
@@ -17,7 +17,7 @@ celery_app.conf.update(
     timezone='UTC',
     enable_utc=True,
     task_routes={
-        'app.services.tasks.long_text_processing': 'long-running',
+        'app.services.celery_app.long_text_processing': 'long-running',
     }
 )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,3 +60,13 @@ def test_invalid_text_request():
     long_text = "a" * 20000
     response = client.post("/api/v1/process", json={"content": long_text})
     assert response.status_code == 422
+
+def test_invalid_style_request():
+    """测试无效风格参数"""
+    test_data = {
+        "content": "测试文本",
+        "style": "unknown"
+    }
+
+    response = client.post("/api/v1/process", json=test_data)
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- 修正 Celery 配置中的 include 路径，更新路由并调整注释
- 异步任务状态查询改用 `celery_app.AsyncResult`
- README 修正项目结构中的主程序名称
- 新增无效风格参数的接口测试

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6866096274c4832e909f86dc927fe338