### PR TITLE
Redesign academic polishing workspace

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Academic Polishing System</title>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>document.documentElement.classList.add('redesign-pending');</script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.min.js" defer></script>
     <style>
         * {
             margin: 0;
@@ -370,6 +372,8 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="workspace.css">
+    <script src="workspace.js" defer></script>
 </head>
 <body>
     <div class="container">
@@ -753,4 +757,3 @@
     </script>
 </body>
 </html>
-

--- a/docs/index_cn.html
+++ b/docs/index_cn.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI学术润色系统</title>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>document.documentElement.classList.add('redesign-pending');</script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.min.js" defer></script>
     <style>
         * {
             margin: 0;
@@ -370,6 +372,8 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="workspace.css">
+    <script src="workspace.js" defer></script>
 </head>
 <body>
     <div class="container">

--- a/docs/workspace.css
+++ b/docs/workspace.css
@@ -1,0 +1,1268 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap");
+
+:root {
+    --canvas: #ffffff;
+    --surface: #ffffff;
+    --surface-subtle: #f7f9fc;
+    --ink: #10223f;
+    --ink-soft: #506079;
+    --ink-faint: #718096;
+    --line: #d8e0eb;
+    --line-strong: #bcc8d8;
+    --blue: #1f5fe5;
+    --blue-deep: #1649b8;
+    --blue-pale: #eef4ff;
+    --coral: #ee5c52;
+    --coral-pale: #fff2f0;
+    --success: #268a48;
+    --success-pale: #edf9f1;
+    --danger: #b42318;
+    --danger-pale: #fff2f0;
+    --shadow-focus: 0 0 0 4px rgba(31, 95, 229, 0.14);
+    --font-ui: "DM Sans", "PingFang SC", "Microsoft YaHei", sans-serif;
+    --font-editor: "Source Serif 4", "Songti SC", "STSong", Georgia, serif;
+    --radius-sm: 7px;
+    --radius-md: 10px;
+    --page-gutter: clamp(18px, 2vw, 32px);
+}
+
+html {
+    color-scheme: light;
+    scroll-behavior: smooth;
+}
+
+html.redesign-pending .container {
+    visibility: hidden;
+}
+
+body {
+    min-width: 320px;
+    min-height: 100vh;
+    margin: 0;
+    color: var(--ink);
+    background: var(--canvas);
+    font-family: var(--font-ui);
+    font-size: 16px;
+    line-height: 1.5;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+}
+
+button,
+textarea,
+input {
+    font: inherit;
+}
+
+button,
+a,
+textarea,
+input {
+    -webkit-tap-highlight-color: transparent;
+}
+
+button {
+    color: inherit;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+.app-root *,
+.app-root *::before,
+.app-root *::after {
+    box-sizing: border-box;
+}
+
+.app-root {
+    min-height: 100vh;
+    background:
+        linear-gradient(var(--line), var(--line)) 0 67px / 100% 1px no-repeat,
+        var(--canvas);
+}
+
+.skip-link {
+    position: fixed;
+    z-index: 100;
+    top: 10px;
+    left: 10px;
+    padding: 10px 14px;
+    border-radius: var(--radius-sm);
+    color: #ffffff;
+    background: var(--ink);
+    transform: translateY(-160%);
+    transition: transform 160ms ease;
+}
+
+.skip-link:focus-visible {
+    transform: translateY(0);
+}
+
+.topbar {
+    display: flex;
+    min-height: 68px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 10px var(--page-gutter);
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--ink);
+    text-decoration: none;
+}
+
+.brand-mark {
+    display: grid;
+    width: 38px;
+    height: 38px;
+    flex: 0 0 auto;
+    place-items: center;
+    border: 1px solid #a9c2fa;
+    border-radius: 9px;
+    color: var(--blue);
+    background: #ffffff;
+}
+
+.brand-mark svg {
+    width: 23px;
+    height: 23px;
+}
+
+.brand-name {
+    font-family: var(--font-editor);
+    font-size: clamp(1.12rem, 1.8vw, 1.42rem);
+    font-weight: 650;
+    letter-spacing: -0.015em;
+}
+
+.language-link {
+    display: inline-flex;
+    min-height: 42px;
+    align-items: center;
+    gap: 9px;
+    padding: 0 13px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    color: var(--ink);
+    background: #ffffff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition:
+        border-color 150ms ease,
+        background-color 150ms ease;
+}
+
+.language-link:hover {
+    border-color: var(--line-strong);
+    background: var(--surface-subtle);
+}
+
+.language-link svg {
+    width: 18px;
+    height: 18px;
+}
+
+.page-shell {
+    width: 100%;
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: clamp(26px, 2.2vw, 34px) var(--page-gutter) 38px;
+}
+
+.intro {
+    max-width: 900px;
+    margin: 0 0 clamp(18px, 1.3vw, 20px);
+}
+
+.intro h1 {
+    max-width: 1040px;
+    margin: 0;
+    color: var(--ink);
+    font-family: var(--font-editor);
+    font-size: clamp(2.55rem, 3.5vw, 3.3rem);
+    font-weight: 600;
+    letter-spacing: -0.045em;
+    line-height: 0.98;
+    text-wrap: balance;
+}
+
+.intro p {
+    max-width: 720px;
+    margin: 15px 0 0;
+    color: var(--ink-soft);
+    font-family: var(--font-editor);
+    font-size: clamp(1.05rem, 1.7vw, 1.28rem);
+    line-height: 1.45;
+    text-wrap: pretty;
+}
+
+.error-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 11px;
+    margin: 0 0 18px;
+    padding: 13px 15px;
+    border: 1px solid #f4b4ae;
+    border-radius: var(--radius-sm);
+    color: var(--danger);
+    background: var(--danger-pale);
+    font-size: 0.92rem;
+}
+
+.error-banner svg {
+    width: 19px;
+    height: 19px;
+    flex: 0 0 auto;
+    margin-top: 1px;
+}
+
+.workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 118px minmax(0, 1.03fr);
+    align-items: stretch;
+}
+
+.workspace-panel {
+    display: flex;
+    min-width: 0;
+    min-height: 590px;
+    flex-direction: column;
+    padding: clamp(18px, 2vw, 26px);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    background: var(--surface);
+}
+
+.panel-header {
+    display: flex;
+    min-height: 42px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    margin-bottom: 14px;
+}
+
+.panel-header h2 {
+    margin: 0;
+    color: var(--ink);
+    font-size: 1.08rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+
+.output-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.result-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--ink-faint);
+    font-size: 0.83rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.result-status::before {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    content: "";
+}
+
+.result-status[data-state="ready"] {
+    color: var(--success);
+}
+
+.result-status[data-state="working"] {
+    color: var(--blue);
+}
+
+.result-status[data-state="working"]::before {
+    animation: status-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes status-pulse {
+    50% {
+        opacity: 0.28;
+        transform: scale(0.7);
+    }
+}
+
+.editor-frame,
+.output-stage {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    background: #ffffff;
+}
+
+.editor-frame:focus-within {
+    border-color: var(--blue);
+    box-shadow: var(--shadow-focus);
+}
+
+.editor-frame textarea {
+    display: block;
+    width: 100%;
+    min-height: 386px;
+    max-height: 540px;
+    margin: 0;
+    padding: 22px 22px 50px;
+    border: 0;
+    border-radius: 0;
+    outline: 0;
+    color: var(--ink);
+    background: transparent;
+    font-family: var(--font-editor);
+    font-size: clamp(1.02rem, 1.35vw, 1.18rem);
+    line-height: 1.75;
+    resize: vertical;
+    transition: none;
+}
+
+.editor-frame textarea::placeholder {
+    color: #8793a5;
+    opacity: 1;
+}
+
+.editor-meta {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    min-height: 38px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 7px 13px;
+    color: var(--ink-faint);
+    background: rgba(255, 255, 255, 0.94);
+    font-size: 0.76rem;
+    font-weight: 500;
+    backdrop-filter: blur(4px);
+}
+
+.editor-meta .shortcut {
+    text-align: right;
+}
+
+.mode-fieldset {
+    min-width: 0;
+    margin: 20px 0 0;
+    padding: 0;
+    border: 0;
+}
+
+.mode-fieldset legend {
+    margin: 0 0 10px;
+    padding: 0;
+    color: var(--ink);
+    font-size: 0.94rem;
+    font-weight: 600;
+}
+
+.mode-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.mode-option {
+    position: relative;
+}
+
+.mode-option input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
+.mode-option label {
+    display: flex;
+    min-height: 66px;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    margin: 0;
+    padding: 9px 7px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    color: var(--ink-soft);
+    background: #ffffff;
+    font-size: 0.77rem;
+    font-weight: 600;
+    text-align: center;
+    cursor: pointer;
+    transition:
+        border-color 150ms ease,
+        color 150ms ease,
+        background-color 150ms ease;
+}
+
+.mode-option label:hover {
+    border-color: #9bb9f7;
+    color: var(--blue-deep);
+    background: #fafcff;
+}
+
+.mode-option label svg {
+    width: 19px;
+    height: 19px;
+    flex: 0 0 auto;
+    stroke-width: 1.7;
+}
+
+.mode-option input:checked + label {
+    border-color: var(--blue);
+    color: var(--blue);
+    background: var(--blue-pale);
+    box-shadow: inset 0 0 0 1px rgba(31, 95, 229, 0.06);
+}
+
+.mode-option input:focus-visible + label {
+    outline: 0;
+    box-shadow: var(--shadow-focus);
+}
+
+.action-row {
+    display: grid;
+    grid-template-columns: 1.25fr 1.1fr auto;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.action-button,
+.copy-button {
+    display: inline-flex;
+    min-height: 48px;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+    padding: 0 17px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    font-weight: 650;
+    letter-spacing: -0.005em;
+    cursor: pointer;
+    transition:
+        transform 150ms ease,
+        border-color 150ms ease,
+        color 150ms ease,
+        background-color 150ms ease,
+        box-shadow 150ms ease;
+}
+
+.action-button svg,
+.copy-button svg {
+    width: 19px;
+    height: 19px;
+    flex: 0 0 auto;
+    stroke-width: 1.8;
+}
+
+.action-button:hover:not(:disabled),
+.copy-button:hover:not(:disabled) {
+    transform: translateY(-1px);
+}
+
+.action-button:focus-visible,
+.copy-button:focus-visible,
+.language-link:focus-visible,
+.brand:focus-visible,
+.reasoning-disclosure summary:focus-visible {
+    outline: 0;
+    box-shadow: var(--shadow-focus);
+}
+
+.action-button:disabled,
+.copy-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.action-primary {
+    color: #ffffff;
+    background: var(--blue);
+    box-shadow: 0 6px 14px rgba(31, 95, 229, 0.17);
+}
+
+.action-primary:hover:not(:disabled) {
+    background: var(--blue-deep);
+    box-shadow: 0 8px 18px rgba(31, 95, 229, 0.21);
+}
+
+.action-secondary,
+.copy-button {
+    border-color: var(--line);
+    color: var(--ink);
+    background: #ffffff;
+}
+
+.action-secondary:hover:not(:disabled),
+.copy-button:hover:not(:disabled) {
+    border-color: var(--line-strong);
+    background: var(--surface-subtle);
+}
+
+.action-quiet {
+    padding-inline: 12px;
+    color: var(--ink-soft);
+    background: transparent;
+}
+
+.action-quiet:hover:not(:disabled) {
+    color: var(--ink);
+    background: var(--surface-subtle);
+}
+
+.copy-button {
+    min-height: 40px;
+    padding-inline: 13px;
+    font-size: 0.8rem;
+}
+
+.proof-rail {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: space-evenly;
+    padding: 70px 0 86px;
+    color: var(--coral);
+    pointer-events: none;
+}
+
+.proof-mark {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-family: var(--font-editor);
+    font-size: 0.72rem;
+    font-style: italic;
+    white-space: nowrap;
+}
+
+.proof-line {
+    height: 0;
+    flex: 1 1 auto;
+    border-top: 1px dashed rgba(238, 92, 82, 0.75);
+}
+
+.proof-mark svg {
+    width: 17px;
+    height: 17px;
+    flex: 0 0 auto;
+    stroke-width: 1.7;
+}
+
+.proof-mark:nth-child(2) {
+    transform: translateY(7px);
+}
+
+.proof-mark:nth-child(3) {
+    transform: translateY(-4px);
+}
+
+.output-stage {
+    display: flex;
+    min-height: 402px;
+    flex: 1 1 auto;
+    flex-direction: column;
+}
+
+.empty-state,
+.loading-state {
+    display: grid;
+    min-height: 400px;
+    padding: 36px;
+    place-items: center;
+    text-align: center;
+}
+
+.empty-state-inner,
+.loading-state-inner {
+    max-width: 300px;
+}
+
+.empty-state-icon {
+    display: grid;
+    width: 54px;
+    height: 64px;
+    margin: 0 auto 18px;
+    place-items: center;
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    color: var(--blue);
+    background:
+        linear-gradient(var(--line), var(--line)) 12px 23px / 30px 1px no-repeat,
+        linear-gradient(var(--line), var(--line)) 12px 31px / 24px 1px no-repeat,
+        linear-gradient(var(--line), var(--line)) 12px 39px / 28px 1px no-repeat,
+        #ffffff;
+}
+
+.empty-state-icon svg {
+    width: 20px;
+    height: 20px;
+    transform: translate(12px, -21px);
+}
+
+.empty-state h3,
+.loading-state h3 {
+    margin: 0;
+    color: var(--ink);
+    font-family: var(--font-editor);
+    font-size: 1.28rem;
+    font-weight: 600;
+}
+
+.empty-state p,
+.loading-state p {
+    margin: 8px 0 0;
+    color: var(--ink-faint);
+    font-size: 0.86rem;
+    line-height: 1.55;
+}
+
+.spinner {
+    width: 32px;
+    height: 32px;
+    margin: 0 auto 18px;
+    border: 2px solid #cbd8f2;
+    border-top-color: var(--blue);
+    border-radius: 50%;
+    animation: spin 780ms linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.demo-notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin: 15px 15px 0;
+    padding: 11px 13px;
+    border: 1px solid #f4c2bd;
+    border-radius: var(--radius-sm);
+    color: #8d2f28;
+    background: var(--coral-pale);
+    font-size: 0.8rem;
+    line-height: 1.5;
+}
+
+.demo-notice svg {
+    width: 18px;
+    height: 18px;
+    flex: 0 0 auto;
+    margin-top: 1px;
+}
+
+.result-prose {
+    min-height: 398px;
+    padding: 25px 27px;
+    color: var(--ink);
+    font-family: var(--font-editor);
+    font-size: clamp(1rem, 1.27vw, 1.16rem);
+    line-height: 1.76;
+    overflow-wrap: anywhere;
+}
+
+.result-prose > :first-child {
+    margin-top: 0;
+}
+
+.result-prose > :last-child {
+    margin-bottom: 0;
+}
+
+.result-prose p,
+.result-prose ul,
+.result-prose ol,
+.result-prose blockquote {
+    margin: 0 0 1em;
+}
+
+.result-prose h1,
+.result-prose h2,
+.result-prose h3,
+.result-prose h4 {
+    margin: 1.15em 0 0.45em;
+    color: var(--ink);
+    font-weight: 650;
+    line-height: 1.22;
+}
+
+.result-prose h1 {
+    font-size: 1.55em;
+}
+
+.result-prose h2 {
+    font-size: 1.35em;
+}
+
+.result-prose h3 {
+    font-size: 1.17em;
+}
+
+.result-prose ul,
+.result-prose ol {
+    padding-left: 1.3em;
+}
+
+.result-prose blockquote {
+    padding-left: 1em;
+    border-left: 2px solid var(--coral);
+    color: var(--ink-soft);
+}
+
+.detection-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 20px;
+    margin-bottom: 22px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--line);
+}
+
+.detection-heading h3 {
+    margin: 0;
+    font-family: var(--font-editor);
+    font-size: 1.3rem;
+}
+
+.signal-value {
+    color: var(--blue);
+    font-family: var(--font-ui);
+    font-size: 1.35rem;
+    font-weight: 700;
+}
+
+.detection-summary {
+    margin: 0 0 23px;
+    color: var(--ink-soft);
+    font-family: var(--font-ui);
+    font-size: 0.92rem;
+}
+
+.score-list {
+    display: grid;
+    gap: 16px;
+    margin: 0;
+}
+
+.score-row {
+    display: grid;
+    grid-template-columns: 130px 1fr 54px;
+    align-items: center;
+    gap: 12px;
+}
+
+.score-row dt,
+.score-row dd {
+    margin: 0;
+    font-family: var(--font-ui);
+    font-size: 0.82rem;
+}
+
+.score-row dt {
+    color: var(--ink-soft);
+}
+
+.score-bar {
+    height: 5px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: #e9eef5;
+}
+
+.score-bar span {
+    display: block;
+    width: var(--score);
+    height: 100%;
+    border-radius: inherit;
+    background: var(--blue);
+}
+
+.score-number {
+    color: var(--ink);
+    font-weight: 650;
+    text-align: right;
+}
+
+.reasoning-disclosure {
+    margin-top: 14px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    background: var(--surface-subtle);
+}
+
+.reasoning-disclosure summary {
+    display: flex;
+    min-height: 46px;
+    align-items: center;
+    gap: 10px;
+    padding: 0 14px;
+    border-radius: inherit;
+    color: var(--ink);
+    font-size: 0.84rem;
+    font-weight: 600;
+    cursor: pointer;
+    list-style: none;
+}
+
+.reasoning-disclosure summary::-webkit-details-marker {
+    display: none;
+}
+
+.reasoning-disclosure summary::before {
+    width: 8px;
+    height: 8px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    content: "";
+    transform: rotate(-45deg);
+    transition: transform 150ms ease;
+}
+
+.reasoning-disclosure[open] summary::before {
+    transform: rotate(45deg) translate(-2px, -2px);
+}
+
+.reasoning-content {
+    max-height: 300px;
+    overflow: auto;
+    padding: 0 16px 16px 34px;
+    color: var(--ink-soft);
+    font-family: var(--font-editor);
+    font-size: 0.9rem;
+    line-height: 1.65;
+}
+
+.reasoning-content > :first-child {
+    margin-top: 0;
+}
+
+.reasoning-content > :last-child {
+    margin-bottom: 0;
+}
+
+.result-meta {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin: 22px 0 0;
+    padding: 0;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    background: #ffffff;
+}
+
+.meta-item {
+    position: relative;
+    display: grid;
+    min-height: 66px;
+    grid-template-columns: 24px auto;
+    grid-template-rows: auto auto;
+    align-content: center;
+    justify-content: center;
+    column-gap: 10px;
+    padding: 10px 16px;
+}
+
+.meta-item + .meta-item::before {
+    position: absolute;
+    top: 16px;
+    bottom: 16px;
+    left: 0;
+    width: 1px;
+    background: var(--line);
+    content: "";
+}
+
+.meta-item svg {
+    width: 21px;
+    height: 21px;
+    grid-row: 1 / 3;
+    align-self: center;
+    color: var(--ink-faint);
+    stroke-width: 1.6;
+}
+
+.meta-item dt,
+.meta-item dd {
+    margin: 0;
+}
+
+.meta-item dt {
+    color: var(--ink-faint);
+    font-size: 0.7rem;
+    font-weight: 500;
+}
+
+.meta-item dd {
+    max-width: 190px;
+    overflow: hidden;
+    color: var(--blue);
+    font-size: 0.87rem;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.page-note {
+    margin: 24px 0 0;
+    color: var(--ink-faint);
+    font-size: 0.74rem;
+    text-align: center;
+}
+
+.sr-only {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    overflow: hidden !important;
+    margin: -1px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    clip: rect(0, 0, 0, 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+}
+
+@media (max-width: 1240px) {
+    .workspace {
+        grid-template-columns: minmax(0, 1fr) 74px minmax(0, 1fr);
+    }
+
+    .proof-mark {
+        font-size: 0;
+    }
+
+    .mode-option label {
+        flex-direction: column;
+        gap: 5px;
+    }
+}
+
+@media (max-width: 960px) {
+    .page-shell {
+        padding-top: 40px;
+    }
+
+    .intro h1 {
+        max-width: 710px;
+    }
+
+    .workspace {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .workspace-panel {
+        min-height: 0;
+    }
+
+    .proof-rail {
+        position: relative;
+        min-height: 78px;
+        flex-direction: row;
+        justify-content: center;
+        padding: 0 18px;
+    }
+
+    .proof-rail::before,
+    .proof-rail::after {
+        height: 0;
+        flex: 1 1 auto;
+        border-top: 1px dashed rgba(238, 92, 82, 0.75);
+        content: "";
+    }
+
+    .proof-mark {
+        display: none;
+    }
+
+    .proof-mark:first-child {
+        display: grid;
+        width: 38px;
+        height: 38px;
+        flex: 0 0 auto;
+        margin: 0 13px;
+        place-items: center;
+        border: 1px solid #f4aaa4;
+        border-radius: 50%;
+        background: #ffffff;
+        font-size: 0;
+        transform: rotate(90deg);
+    }
+
+    .proof-mark:first-child .proof-line {
+        display: none;
+    }
+
+    .output-stage {
+        min-height: 360px;
+    }
+
+    .empty-state,
+    .loading-state {
+        min-height: 358px;
+    }
+
+    .result-prose {
+        min-height: 356px;
+    }
+}
+
+@media (max-width: 680px) {
+    .app-root {
+        background:
+            linear-gradient(var(--line), var(--line)) 0 63px / 100% 1px no-repeat,
+            var(--canvas);
+    }
+
+    .topbar {
+        min-height: 64px;
+        padding-inline: 16px;
+    }
+
+    .brand {
+        gap: 9px;
+    }
+
+    .brand-mark {
+        width: 34px;
+        height: 34px;
+        border-radius: 8px;
+    }
+
+    .brand-mark svg {
+        width: 20px;
+        height: 20px;
+    }
+
+    .brand-name {
+        font-size: 1rem;
+    }
+
+    .language-link {
+        min-height: 40px;
+        padding-inline: 11px;
+    }
+
+    .language-link svg {
+        display: none;
+    }
+
+    .page-shell {
+        padding: 34px 16px 30px;
+    }
+
+    .intro {
+        margin-bottom: 24px;
+    }
+
+    .intro h1 {
+        font-size: clamp(2.28rem, 11.5vw, 3.15rem);
+        line-height: 0.99;
+    }
+
+    .intro p {
+        margin-top: 12px;
+        font-size: 1rem;
+    }
+
+    .workspace-panel {
+        padding: 16px;
+    }
+
+    .panel-header {
+        align-items: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .output-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .editor-frame textarea {
+        min-height: 285px;
+        padding: 18px 18px 52px;
+        font-size: 1.05rem;
+    }
+
+    .editor-meta {
+        align-items: flex-end;
+    }
+
+    .editor-meta .shortcut {
+        max-width: 150px;
+        line-height: 1.25;
+    }
+
+    .mode-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 9px;
+    }
+
+    .mode-option label {
+        min-height: 58px;
+        flex-direction: row;
+        font-size: 0.82rem;
+    }
+
+    .action-row {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .action-button {
+        min-height: 50px;
+    }
+
+    .proof-rail {
+        min-height: 74px;
+        padding-inline: 8px;
+    }
+
+    .empty-state,
+    .loading-state {
+        min-height: 315px;
+        padding: 28px 20px;
+    }
+
+    .output-stage {
+        min-height: 317px;
+    }
+
+    .result-prose {
+        min-height: 315px;
+        padding: 21px 19px;
+        font-size: 1.04rem;
+    }
+
+    .score-row {
+        grid-template-columns: 104px 1fr 48px;
+        gap: 9px;
+    }
+
+    .result-meta {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .meta-item:nth-child(3)::before {
+        top: 0;
+        right: 16px;
+        bottom: auto;
+        left: 16px;
+        width: auto;
+        height: 1px;
+    }
+
+    .meta-item:nth-child(3)::after {
+        position: absolute;
+        top: 0;
+        right: -100%;
+        left: 100%;
+        height: 1px;
+        background: var(--line);
+        content: "";
+    }
+}
+
+@media (max-width: 420px) {
+    .language-link {
+        font-size: 0.78rem;
+    }
+
+    .brand-name {
+        max-width: 155px;
+        line-height: 1.05;
+    }
+
+    .editor-meta .shortcut {
+        display: none;
+    }
+
+    .detection-heading {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .score-row {
+        grid-template-columns: minmax(0, 1fr) 48px;
+    }
+
+    .score-row dt {
+        grid-column: 1 / 3;
+    }
+
+    .meta-item {
+        grid-template-columns: 20px auto;
+        column-gap: 8px;
+        padding-inline: 10px;
+    }
+
+    .meta-item svg {
+        width: 18px;
+        height: 18px;
+    }
+
+    .meta-item dd {
+        font-size: 0.8rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+@media (forced-colors: active) {
+    .mode-option input:checked + label,
+    .action-button,
+    .copy-button,
+    .language-link {
+        border: 1px solid ButtonText;
+    }
+
+    .result-status::before,
+    .score-bar span {
+        background: CanvasText;
+    }
+}

--- a/docs/workspace.js
+++ b/docs/workspace.js
@@ -1,0 +1,710 @@
+(() => {
+    "use strict";
+
+    const translations = {
+        en: {
+            title: "AI Academic Polisher",
+            skip: "Skip to writing workspace",
+            languageLabel: "中文",
+            languageHref: "index_cn.html",
+            headline: "Make every sentence earn its place.",
+            subhead: "Refine academic prose while preserving your argument and voice.",
+            workspaceLabel: "Academic polishing workspace",
+            draft: "Draft",
+            inputLabel: "Text to polish",
+            placeholder: "Paste an academic paragraph, abstract, or research note…",
+            characterUnit: "characters",
+            shortcut: "⌘ / Ctrl + Enter to polish",
+            modeLegend: "Polishing mode",
+            modes: {
+                academic: "Academic",
+                formal: "Formal",
+                casual: "Clear",
+                creative: "Creative"
+            },
+            polish: "Polish draft",
+            detect: "Check AI signals",
+            clear: "Clear",
+            output: "Polished version",
+            waiting: "Waiting for draft",
+            workingPolish: "Polishing…",
+            workingDetect: "Analyzing…",
+            ready: "Ready to copy",
+            analysisReady: "Analysis ready",
+            copy: "Copy text",
+            copied: "Copied",
+            emptyTitle: "Your revision will appear here.",
+            emptyText: "Add a draft, choose a mode, and polish when you are ready.",
+            loadingPolishTitle: "Refining your draft",
+            loadingPolishText: "DeepSeek-R1 is reviewing structure, clarity, and voice.",
+            loadingDetectTitle: "Reading for AI signals",
+            loadingDetectText: "The analysis may take a few moments.",
+            reasoning: "Review editorial notes",
+            demoTitle: "Demo response",
+            demoText: "This result is simulated. Configure an API key on the backend to use DeepSeek-R1.",
+            metaSignal: "AI signal",
+            metaTime: "Time",
+            metaMode: "Mode",
+            metaService: "Service",
+            secondUnit: "sec",
+            unknown: "Unknown",
+            requiredPolish: "Add some text before polishing your draft.",
+            requiredDetect: "Add some text before checking AI signals.",
+            processError: "The draft could not be polished",
+            detectError: "The AI signal check could not be completed",
+            clipboardError: "Copying was blocked by the browser. Select the result and copy it manually.",
+            emptyResult: "The service returned an empty result.",
+            detectionTitle: "AI signal check",
+            confidence: "Confidence",
+            confidenceLevels: {
+                low: "Low",
+                medium: "Medium",
+                high: "High"
+            },
+            detectionSummary: "This is a probabilistic signal, not proof of authorship.",
+            patternScore: "Pattern score",
+            complexityScore: "Complexity score",
+            semanticScore: "Semantic score",
+            note: "DeepSeek-R1 processing through FastAPI",
+            railLabels: ["structure", "clarity", "voice"]
+        },
+        zh: {
+            title: "AI 学术润色",
+            skip: "跳转到写作工作区",
+            languageLabel: "English",
+            languageHref: "index.html",
+            headline: "让每一句话都有分量。",
+            subhead: "在保留论点与个人表达的同时，让学术写作更准确、更清晰。",
+            workspaceLabel: "学术润色工作区",
+            draft: "原始文本",
+            inputLabel: "需要润色的文本",
+            placeholder: "粘贴论文段落、摘要或研究笔记…",
+            characterUnit: "字符",
+            shortcut: "⌘ / Ctrl + Enter 开始润色",
+            modeLegend: "润色模式",
+            modes: {
+                academic: "学术",
+                formal: "正式",
+                casual: "清晰",
+                creative: "创意"
+            },
+            polish: "润色文本",
+            detect: "检测 AI 痕迹",
+            clear: "清空",
+            output: "润色结果",
+            waiting: "等待输入",
+            workingPolish: "正在润色…",
+            workingDetect: "正在分析…",
+            ready: "可以复制",
+            analysisReady: "分析完成",
+            copy: "复制文本",
+            copied: "已复制",
+            emptyTitle: "润色结果会显示在这里。",
+            emptyText: "输入文本并选择模式，准备好后即可开始润色。",
+            loadingPolishTitle: "正在精炼文本",
+            loadingPolishText: "DeepSeek-R1 正在检查结构、清晰度和表达方式。",
+            loadingDetectTitle: "正在分析 AI 痕迹",
+            loadingDetectText: "分析可能需要一点时间。",
+            reasoning: "查看编辑说明",
+            demoTitle: "演示结果",
+            demoText: "当前结果为模拟数据。请在后端配置 API 密钥以使用 DeepSeek-R1。",
+            metaSignal: "AI 痕迹",
+            metaTime: "用时",
+            metaMode: "模式",
+            metaService: "服务",
+            secondUnit: "秒",
+            unknown: "未知",
+            requiredPolish: "请先输入需要润色的文本。",
+            requiredDetect: "请先输入需要检测的文本。",
+            processError: "无法完成文本润色",
+            detectError: "无法完成 AI 痕迹检测",
+            clipboardError: "浏览器阻止了复制操作，请选中结果后手动复制。",
+            emptyResult: "服务未返回润色结果。",
+            detectionTitle: "AI 痕迹检测",
+            confidence: "置信度",
+            confidenceLevels: {
+                low: "低",
+                medium: "中",
+                high: "高"
+            },
+            detectionSummary: "该结果仅为概率信号，不能作为作者身份的确定证据。",
+            patternScore: "模式得分",
+            complexityScore: "复杂度得分",
+            semanticScore: "语义得分",
+            note: "由 FastAPI 调用 DeepSeek-R1 处理",
+            railLabels: ["结构", "清晰", "表达"]
+        }
+    };
+
+    const icon = (name) => {
+        const icons = {
+            feather: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M20.2 3.8c-3.9-.7-7.4.3-10.1 3-2.8 2.8-3.8 6.4-3.1 10.5 4 .7 7.6-.4 10.3-3.2 2.7-2.8 3.7-6.3 2.9-10.3Z" stroke="currentColor" stroke-width="1.7"/>
+                    <path d="M4 21 17.5 7.4M8.2 16.7h4.1M11.2 13.7l.1-4.2" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+                </svg>`,
+            globe: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <circle cx="12" cy="12" r="8.5" stroke="currentColor" stroke-width="1.6"/>
+                    <path d="M3.8 12h16.4M12 3.5c2.2 2.3 3.2 5.1 3.2 8.5S14.2 18.2 12 20.5C9.8 18.2 8.8 15.4 8.8 12S9.8 5.8 12 3.5Z" stroke="currentColor" stroke-width="1.6"/>
+                </svg>`,
+            book: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M4 5.8c2.7-.7 5.3-.2 8 1.4v12c-2.7-1.6-5.3-2.1-8-1.4v-12Zm16 0c-2.7-.7-5.3-.2-8 1.4v12c2.7-1.6 5.3-2.1 8-1.4v-12Z" stroke="currentColor" stroke-linejoin="round"/>
+                </svg>`,
+            formal: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="m3 9 9-5 9 5H3Zm2 2h14M6 11v6m4-6v6m4-6v6m4-6v6M4 20h16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>`,
+            sparkles: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 3c.4 3.6 2.4 5.6 6 6-3.6.4-5.6 2.4-6 6-.4-3.6-2.4-5.6-6-6 3.6-.4 5.6-2.4 6-6Zm6 11.5c.2 1.7 1.2 2.7 3 3-1.8.3-2.8 1.3-3 3-.2-1.7-1.2-2.7-3-3 1.8-.3 2.8-1.3 3-3ZM5.2 15c.2 1.2.9 1.9 2.1 2.1-1.2.2-1.9.9-2.1 2.1C5 18 4.3 17.3 3.1 17.1c1.2-.2 1.9-.9 2.1-2.1Z" stroke="currentColor" stroke-linejoin="round"/>
+                </svg>`,
+            bulb: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M8.3 15.6A7 7 0 1 1 15.7 15.6c-.8.6-1.2 1.5-1.2 2.4h-5c0-.9-.4-1.8-1.2-2.4ZM9.5 21h5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>`,
+            wand: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="m4 20 10.2-10.2m-3-3 3 3m-4.9 3.9 3 3M17 3v3m-1.5-1.5h3M20 10v2m-1-1h2M8 3v2M7 4h2" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>`,
+            pulse: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M2.5 12h4l2-6 3.4 12 2.5-8 1.8 2h5.3" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>`,
+            copy: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <rect x="8" y="7" width="11" height="13" rx="1.8" stroke="currentColor"/>
+                    <path d="M16 7V5.8C16 4.8 15.2 4 14.2 4H5.8C4.8 4 4 4.8 4 5.8v10.4C4 17.2 4.8 18 5.8 18H8" stroke="currentColor"/>
+                </svg>`,
+            alert: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 3 2.8 20h18.4L12 3Z" stroke="currentColor" stroke-linejoin="round"/>
+                    <path d="M12 9v5m0 3.2v.1" stroke="currentColor" stroke-linecap="round"/>
+                </svg>`,
+            arrow: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M3 12h17m-5-5 5 5-5 5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>`,
+            chart: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M4 20V10h4v10m2 0V4h4v16m2 0v-7h4v7M2.5 20.5h19" stroke="currentColor" stroke-linejoin="round"/>
+                </svg>`,
+            clock: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <circle cx="12" cy="12" r="9" stroke="currentColor"/>
+                    <path d="M12 7v5l3.2 2" stroke="currentColor" stroke-linecap="round"/>
+                </svg>`,
+            branch: `
+                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <circle cx="6" cy="5" r="2" stroke="currentColor"/>
+                    <circle cx="18" cy="8" r="2" stroke="currentColor"/>
+                    <circle cx="18" cy="18" r="2" stroke="currentColor"/>
+                    <path d="M6 7v8a3 3 0 0 0 3 3h7M6 11h7a3 3 0 0 0 3-3" stroke="currentColor"/>
+                </svg>`
+        };
+        return icons[name] || "";
+    };
+
+    const language = document.documentElement.lang.toLowerCase().startsWith("zh") ? "zh" : "en";
+    const t = translations[language];
+    const root = document.querySelector(".container");
+
+    if (!root) {
+        document.documentElement.classList.remove("redesign-pending");
+        return;
+    }
+
+    document.title = t.title;
+
+    const modes = [
+        ["academic", "book"],
+        ["formal", "formal"],
+        ["casual", "sparkles"],
+        ["creative", "bulb"]
+    ];
+
+    root.className = "app-root";
+    root.innerHTML = `
+        <a class="skip-link" href="#writing-workspace">${t.skip}</a>
+        <header class="topbar">
+            <a class="brand" href="#" aria-label="${t.title}">
+                <span class="brand-mark">${icon("feather")}</span>
+                <span class="brand-name">${t.title}</span>
+            </a>
+            <a class="language-link" href="${t.languageHref}" hreflang="${language === "en" ? "zh" : "en"}">
+                ${icon("globe")}
+                <span>${t.languageLabel}</span>
+            </a>
+        </header>
+
+        <main class="page-shell" id="main-content">
+            <section class="intro" aria-labelledby="page-title">
+                <h1 id="page-title">${t.headline}</h1>
+                <p>${t.subhead}</p>
+            </section>
+
+            <div class="error-banner" id="errorBanner" role="alert" tabindex="-1" hidden>
+                ${icon("alert")}
+                <span id="errorText"></span>
+            </div>
+
+            <section class="workspace" id="writing-workspace" aria-label="${t.workspaceLabel}">
+                <form class="workspace-panel draft-panel" id="polishForm" novalidate>
+                    <div class="panel-header">
+                        <h2>${t.draft}</h2>
+                    </div>
+
+                    <div class="editor-frame">
+                        <label class="sr-only" for="textInput">${t.inputLabel}</label>
+                        <textarea id="textInput" name="content" maxlength="10000" placeholder="${t.placeholder}" spellcheck="true"></textarea>
+                        <div class="editor-meta">
+                            <span id="characterCount">0 / 10,000 ${t.characterUnit}</span>
+                            <span class="shortcut">${t.shortcut}</span>
+                        </div>
+                    </div>
+
+                    <fieldset class="mode-fieldset">
+                        <legend>${t.modeLegend}</legend>
+                        <div class="mode-grid">
+                            ${modes.map(([value, iconName], index) => `
+                                <div class="mode-option">
+                                    <input type="radio" name="style" id="style-${value}" value="${value}" ${index === 0 ? "checked" : ""}>
+                                    <label for="style-${value}">
+                                        ${icon(iconName)}
+                                        <span>${t.modes[value]}</span>
+                                    </label>
+                                </div>
+                            `).join("")}
+                        </div>
+                    </fieldset>
+
+                    <div class="action-row">
+                        <button class="action-button action-primary" id="processBtn" type="submit">
+                            ${icon("wand")}
+                            <span>${t.polish}</span>
+                        </button>
+                        <button class="action-button action-secondary" id="detectBtn" type="button">
+                            ${icon("pulse")}
+                            <span>${t.detect}</span>
+                        </button>
+                        <button class="action-button action-quiet" id="clearBtn" type="button">${t.clear}</button>
+                    </div>
+                </form>
+
+                <div class="proof-rail" aria-hidden="true">
+                    ${t.railLabels.map((label) => `
+                        <div class="proof-mark">
+                            <span class="proof-line"></span>
+                            <span>${label}</span>
+                            ${icon("arrow")}
+                        </div>
+                    `).join("")}
+                </div>
+
+                <article class="workspace-panel output-panel" aria-labelledby="outputTitle">
+                    <div class="panel-header">
+                        <h2 id="outputTitle">${t.output}</h2>
+                        <div class="output-actions">
+                            <span class="result-status" id="resultStatus" data-state="idle">${t.waiting}</span>
+                            <button class="copy-button" id="copyBtn" type="button" disabled>
+                                ${icon("copy")}
+                                <span data-copy-label>${t.copy}</span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="output-stage" id="outputStage" aria-live="polite" aria-busy="false">
+                        <div class="empty-state" id="emptyState">
+                            <div class="empty-state-inner">
+                                <span class="empty-state-icon">${icon("feather")}</span>
+                                <h3>${t.emptyTitle}</h3>
+                                <p>${t.emptyText}</p>
+                            </div>
+                        </div>
+
+                        <div class="loading-state" id="loadingState" hidden>
+                            <div class="loading-state-inner">
+                                <div class="spinner" aria-hidden="true"></div>
+                                <h3 id="loadingTitle">${t.loadingPolishTitle}</h3>
+                                <p id="loadingText">${t.loadingPolishText}</p>
+                            </div>
+                        </div>
+
+                        <div class="demo-notice" id="demoNotice" hidden>
+                            ${icon("alert")}
+                            <span><strong>${t.demoTitle}.</strong> ${t.demoText}</span>
+                        </div>
+
+                        <div class="result-prose" id="resultText" hidden></div>
+                    </div>
+
+                    <details class="reasoning-disclosure" id="reasoningSection" hidden>
+                        <summary>${t.reasoning}</summary>
+                        <div class="reasoning-content" id="reasoningContent"></div>
+                    </details>
+                </article>
+            </section>
+
+            <dl class="result-meta" id="resultMeta" hidden>
+                <div class="meta-item">
+                    ${icon("chart")}
+                    <dt>${t.metaSignal}</dt>
+                    <dd id="aiProbability">—</dd>
+                </div>
+                <div class="meta-item">
+                    ${icon("clock")}
+                    <dt>${t.metaTime}</dt>
+                    <dd id="processingTime">—</dd>
+                </div>
+                <div class="meta-item">
+                    ${icon("book")}
+                    <dt>${t.metaMode}</dt>
+                    <dd id="styleUsed">—</dd>
+                </div>
+                <div class="meta-item">
+                    ${icon("branch")}
+                    <dt>${t.metaService}</dt>
+                    <dd id="apiUsed">—</dd>
+                </div>
+            </dl>
+
+            <p class="page-note">${t.note}</p>
+        </main>
+    `;
+
+    document.documentElement.classList.remove("redesign-pending");
+
+    const defaultApiUrl = "https://oneai-polish.onrender.com";
+    const previewApiUrl = new URLSearchParams(window.location.search).get("api");
+    const isLocalPreview = ["127.0.0.1", "localhost", "::1"].includes(window.location.hostname);
+    const WORKSPACE_API_URL = isLocalPreview && previewApiUrl
+        ? previewApiUrl.replace(/\/+$/, "")
+        : defaultApiUrl;
+    const textInput = document.getElementById("textInput");
+    const polishForm = document.getElementById("polishForm");
+    const processBtn = document.getElementById("processBtn");
+    const detectBtn = document.getElementById("detectBtn");
+    const clearBtn = document.getElementById("clearBtn");
+    const copyBtn = document.getElementById("copyBtn");
+    const copyLabel = copyBtn.querySelector("[data-copy-label]");
+    const characterCount = document.getElementById("characterCount");
+    const errorBanner = document.getElementById("errorBanner");
+    const errorText = document.getElementById("errorText");
+    const outputStage = document.getElementById("outputStage");
+    const emptyState = document.getElementById("emptyState");
+    const loadingState = document.getElementById("loadingState");
+    const loadingTitle = document.getElementById("loadingTitle");
+    const loadingText = document.getElementById("loadingText");
+    const demoNotice = document.getElementById("demoNotice");
+    const resultText = document.getElementById("resultText");
+    const resultStatus = document.getElementById("resultStatus");
+    const reasoningSection = document.getElementById("reasoningSection");
+    const reasoningContent = document.getElementById("reasoningContent");
+    const resultMeta = document.getElementById("resultMeta");
+    const aiProbability = document.getElementById("aiProbability");
+    const processingTime = document.getElementById("processingTime");
+    const styleUsed = document.getElementById("styleUsed");
+    const apiUsed = document.getElementById("apiUsed");
+    let activeController = null;
+    let lastCopyText = "";
+
+    const selectedStyle = () => polishForm.elements.style.value || "academic";
+
+    const formatPercentage = (value) => {
+        const number = Number(value);
+        return Number.isFinite(number) ? `${(number * 100).toFixed(1)}%` : t.unknown;
+    };
+
+    const formatSeconds = (value) => {
+        const number = Number(value);
+        return Number.isFinite(number) ? `${number.toFixed(1)} ${t.secondUnit}` : t.unknown;
+    };
+
+    const setStatus = (text, state = "idle") => {
+        resultStatus.textContent = text;
+        resultStatus.dataset.state = state;
+    };
+
+    const updateCounter = () => {
+        const length = textInput.value.length;
+        characterCount.textContent = `${length.toLocaleString(language === "zh" ? "zh-CN" : "en-US")} / 10,000 ${t.characterUnit}`;
+    };
+
+    const showError = (heading, detail = "") => {
+        errorText.textContent = detail ? `${heading}: ${detail}` : heading;
+        errorBanner.hidden = false;
+        errorBanner.focus({ preventScroll: true });
+        errorBanner.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    };
+
+    const clearError = () => {
+        errorBanner.hidden = true;
+        errorText.textContent = "";
+    };
+
+    const safeMarkdown = (element, source) => {
+        const value = String(source || "");
+        if (window.marked && window.DOMPurify) {
+            element.innerHTML = window.DOMPurify.sanitize(window.marked.parse(value), {
+                USE_PROFILES: { html: true }
+            });
+        } else {
+            element.textContent = value;
+        }
+    };
+
+    const setBusy = (busy, action = "polish") => {
+        outputStage.setAttribute("aria-busy", String(busy));
+        processBtn.disabled = busy;
+        detectBtn.disabled = busy;
+
+        if (!busy) {
+            return;
+        }
+
+        emptyState.hidden = true;
+        resultText.hidden = true;
+        demoNotice.hidden = true;
+        reasoningSection.hidden = true;
+        reasoningSection.open = false;
+        resultMeta.hidden = true;
+        copyBtn.disabled = true;
+        loadingState.hidden = false;
+
+        const detecting = action === "detect";
+        loadingTitle.textContent = detecting ? t.loadingDetectTitle : t.loadingPolishTitle;
+        loadingText.textContent = detecting ? t.loadingDetectText : t.loadingPolishText;
+        setStatus(detecting ? t.workingDetect : t.workingPolish, "working");
+    };
+
+    const resetOutput = () => {
+        lastCopyText = "";
+        copyBtn.disabled = true;
+        copyLabel.textContent = t.copy;
+        loadingState.hidden = true;
+        resultText.hidden = true;
+        resultText.textContent = "";
+        resultText.classList.remove("detection-result");
+        demoNotice.hidden = true;
+        emptyState.hidden = false;
+        reasoningSection.hidden = true;
+        reasoningSection.open = false;
+        reasoningContent.textContent = "";
+        resultMeta.hidden = true;
+        setStatus(t.waiting, "idle");
+        outputStage.setAttribute("aria-busy", "false");
+    };
+
+    const getContent = (action) => {
+        const content = textInput.value.trim();
+        if (content) {
+            return content;
+        }
+
+        showError(action === "detect" ? t.requiredDetect : t.requiredPolish);
+        textInput.focus();
+        return null;
+    };
+
+    const requestJson = async (endpoint, payload, signal) => {
+        const response = await fetch(`${WORKSPACE_API_URL}${endpoint}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(payload),
+            signal
+        });
+
+        let result = null;
+        try {
+            result = await response.json();
+        } catch {
+            result = null;
+        }
+
+        if (!response.ok) {
+            const detail = result?.message || result?.detail || `${response.status} ${response.statusText}`;
+            throw new Error(detail);
+        }
+
+        return result || {};
+    };
+
+    const setMeta = ({ signal, time, mode, service }) => {
+        aiProbability.textContent = signal;
+        processingTime.textContent = time;
+        styleUsed.textContent = mode;
+        apiUsed.textContent = service;
+        resultMeta.hidden = false;
+    };
+
+    const renderPolishResult = (result) => {
+        const processedText = String(result.processed_text || t.emptyResult);
+        const mode = result.style_used || selectedStyle();
+        const service = result.api_used || "DeepSeek-R1";
+        const reasoning = result.reasoning_content || result.reasoning || "";
+
+        loadingState.hidden = true;
+        emptyState.hidden = true;
+        resultText.classList.remove("detection-result");
+        safeMarkdown(resultText, processedText);
+        resultText.hidden = false;
+        lastCopyText = resultText.innerText.trim();
+        copyBtn.disabled = !lastCopyText;
+        copyLabel.textContent = t.copy;
+
+        if (reasoning) {
+            safeMarkdown(reasoningContent, reasoning);
+            reasoningSection.hidden = false;
+        } else {
+            reasoningSection.hidden = true;
+            reasoningContent.textContent = "";
+        }
+
+        const isDemo = /Demo Mode|演示模式/i.test(service);
+        demoNotice.hidden = !isDemo;
+
+        setMeta({
+            signal: formatPercentage(result.ai_probability),
+            time: formatSeconds(result.processing_time),
+            mode: t.modes[mode] || mode || t.unknown,
+            service
+        });
+        setStatus(t.ready, "ready");
+        outputStage.setAttribute("aria-busy", "false");
+    };
+
+    const renderDetectionResult = (result) => {
+        const signal = formatPercentage(result.ai_probability);
+        const confidenceKey = String(result.confidence_level || "low").toLowerCase();
+        const confidence = t.confidenceLevels[confidenceKey] || result.confidence_level || t.unknown;
+        const analysis = result.analysis || {};
+        const scores = [
+            [t.patternScore, Number(analysis.pattern_score)],
+            [t.complexityScore, Number(analysis.complexity_score)],
+            [t.semanticScore, Number(analysis.semantic_score)]
+        ];
+
+        loadingState.hidden = true;
+        emptyState.hidden = true;
+        demoNotice.hidden = true;
+        reasoningSection.hidden = true;
+        resultText.classList.add("detection-result");
+        resultText.innerHTML = `
+            <div class="detection-heading">
+                <h3>${t.detectionTitle}</h3>
+                <span class="signal-value"></span>
+            </div>
+            <p class="detection-summary"></p>
+            <dl class="score-list">
+                ${scores.map(([label, score]) => {
+                    const percentage = Number.isFinite(score) ? Math.max(0, Math.min(100, score * 100)) : 0;
+                    return `
+                        <div class="score-row">
+                            <dt>${label}</dt>
+                            <dd class="score-bar" aria-hidden="true"><span style="--score: ${percentage.toFixed(1)}%"></span></dd>
+                            <dd class="score-number">${Number.isFinite(score) ? `${percentage.toFixed(1)}%` : "—"}</dd>
+                        </div>
+                    `;
+                }).join("")}
+            </dl>
+        `;
+        resultText.querySelector(".signal-value").textContent = signal;
+        resultText.querySelector(".detection-summary").textContent = `${t.confidence}: ${confidence}. ${t.detectionSummary}`;
+        resultText.hidden = false;
+        lastCopyText = resultText.innerText.trim();
+        copyBtn.disabled = false;
+        copyLabel.textContent = t.copy;
+
+        setMeta({
+            signal,
+            time: formatSeconds(result.processing_time),
+            mode: t.detect,
+            service: "DeepSeek-R1"
+        });
+        setStatus(t.analysisReady, "ready");
+        outputStage.setAttribute("aria-busy", "false");
+    };
+
+    const runAction = async (action) => {
+        const content = getContent(action);
+        if (!content) {
+            return;
+        }
+
+        clearError();
+        activeController?.abort();
+        activeController = new AbortController();
+        setBusy(true, action);
+
+        try {
+            if (action === "detect") {
+                const result = await requestJson("/api/v1/detect", { content }, activeController.signal);
+                renderDetectionResult(result);
+            } else {
+                const result = await requestJson(
+                    "/api/v1/process",
+                    { content, style: selectedStyle() },
+                    activeController.signal
+                );
+                renderPolishResult(result);
+            }
+        } catch (error) {
+            if (error.name === "AbortError") {
+                return;
+            }
+            resetOutput();
+            showError(action === "detect" ? t.detectError : t.processError, error.message);
+        } finally {
+            setBusy(false);
+            activeController = null;
+        }
+    };
+
+    polishForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        runAction("polish");
+    });
+
+    detectBtn.addEventListener("click", () => runAction("detect"));
+
+    clearBtn.addEventListener("click", () => {
+        activeController?.abort();
+        activeController = null;
+        textInput.value = "";
+        updateCounter();
+        clearError();
+        resetOutput();
+        processBtn.disabled = false;
+        detectBtn.disabled = false;
+        textInput.focus();
+    });
+
+    copyBtn.addEventListener("click", async () => {
+        if (!lastCopyText) {
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(lastCopyText);
+            copyLabel.textContent = t.copied;
+            window.setTimeout(() => {
+                copyLabel.textContent = t.copy;
+            }, 1800);
+        } catch {
+            showError(t.clipboardError);
+        }
+    });
+
+    textInput.addEventListener("input", updateCounter);
+    textInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+            event.preventDefault();
+            polishForm.requestSubmit();
+        }
+    });
+
+    updateCounter();
+})();

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-fastapi==0.104.1
+fastapi==0.140.0
 uvicorn[standard]==0.24.0
 python-multipart==0.0.31
 pydantic>=2.7.0,<3.0.0
 pydantic-settings==2.10.1
-httpx==0.25.2
+httpx==0.28.1
 python-dotenv==1.2.2
 starlette>=1.3.1  # 从 main 分支新增
 typing-extensions>=4.0.0  # 从 main 分支新增

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,6 @@
 alembic==1.16.2
 amqp==5.3.1
+annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==3.7.1
 billiard==4.2.1
@@ -10,7 +11,7 @@ click-didyoumean==0.3.1
 click-plugins==1.1.1.2
 click-repl==0.3.0
 ecdsa==0.19.2
-fastapi==0.104.1
+fastapi==0.140.0
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.6.4
@@ -24,9 +25,9 @@ packaging==25.0
 pluggy==1.6.0
 prompt_toolkit==3.0.51
 pyasn1==0.6.4
-pydantic==2.11.7
+pydantic==2.13.4
 pydantic-settings==2.10.1
-pydantic_core==2.33.2
+pydantic_core==2.46.4
 Pygments==2.20.0
 pytest==9.0.3
 python-dateutil==2.9.0.post0
@@ -40,8 +41,8 @@ six==1.17.0
 sniffio==1.3.1
 SQLAlchemy==2.0.35
 starlette==1.3.1
-typing-inspection==0.4.1
-typing_extensions==4.14.0
+typing-inspection==0.4.2
+typing_extensions==4.16.0
 tzdata==2025.2
 uvicorn==0.24.0
 uvloop==0.21.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,23 +1,30 @@
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app
+from app.api.v1 import endpoints
 
-client = TestClient(app)
 
-def test_root():
+@pytest.fixture(scope="module")
+def client():
+    """Run application lifespan hooks for database setup and cleanup."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_root(client):
     """测试根路径"""
     response = client.get("/")
     assert response.status_code == 200
     assert "message" in response.json()
 
-def test_health_check():
+def test_health_check(client):
     """测试健康检查"""
     response = client.get("/api/v1/health")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "healthy"
 
-def test_process_text():
+def test_process_text(client):
     """测试文本处理接口"""
     test_data = {
         "content": "人工智能技术在学术写作中的应用越来越广泛。",
@@ -35,8 +42,17 @@ def test_process_text():
     assert data["ai_probability"] >= 0.0
     assert data["ai_probability"] <= 1.0
 
-def test_async_process_text():
+def test_async_process_text(client, monkeypatch):
     """测试异步文本处理接口"""
+    class StubTask:
+        id = "test-task-id"
+
+    monkeypatch.setattr(
+        endpoints.long_text_processing,
+        "delay",
+        lambda *args, **kwargs: StubTask()
+    )
+
     test_data = {
         "content": "这是一个测试文本，用于验证异步处理功能。",
         "style": "formal"
@@ -50,7 +66,7 @@ def test_async_process_text():
     assert "status" in data
     assert data["status"] == "processing"
 
-def test_invalid_text_request():
+def test_invalid_text_request(client):
     """测试无效请求"""
     # 空文本测试
     response = client.post("/api/v1/process", json={"content": ""})
@@ -61,7 +77,7 @@ def test_invalid_text_request():
     response = client.post("/api/v1/process", json={"content": long_text})
     assert response.status_code == 422
 
-def test_invalid_style_request():
+def test_invalid_style_request(client):
     """测试无效风格参数"""
     test_data = {
         "content": "测试文本",


### PR DESCRIPTION
## What changed

- redesign the English and Chinese polishing pages as a responsive editorial workspace
- add clear draft, polishing, AI-signal, loading, error, copy, and empty states
- sanitize rendered Markdown and keep local API overrides restricted to local previews
- align FastAPI, Starlette, HTTPX, Pydantic, and related lockfile dependencies
- update API tests for application lifespan handling and isolated async queue behavior

## Why

The existing interface was visually dense and difficult to scan on smaller screens. The merged Starlette major update also required matching FastAPI/Pydantic versions and lifecycle-aware tests.

## Impact

Users get a calmer bilingual writing flow with keyboard support, responsive layouts, and more legible result metadata. Backend API behavior remains unchanged.

## Validation

- clean Python 3.14 virtual environment install from `requirements_all.txt`
- `pytest -q` — 6 passed
- `node --check docs/workspace.js`
- `git diff --check`
- Chrome QA at 1536×1024 and 430×932 for English and Chinese
- exercised polish, AI-signal detection, mode selection, copy, clear, loading, and result states against a local mock API
